### PR TITLE
[FE-ENG-AGENT] Add timeout handling for API requests

### DIFF
--- a/app/src/api/auth.ts
+++ b/app/src/api/auth.ts
@@ -2,7 +2,7 @@ import {
   GoogleSignin,
 } from '@react-native-google-signin/google-signin';
 import { Alert } from 'react-native';
-import { API_BASE_URL } from "../utils/utils";
+import { authFetch } from "../utils/fetchUtils";
 import {
   AccessTokenProvider
 } from "../context/AccessTokenContext";
@@ -27,22 +27,22 @@ export const silentLogin = async () => {
 export const onLogin = async () => {
   const res = await signIn();
   if (!res.data) {
-    Alert.alert("error logging in")
-    throw new Error("Error logging in");
+    Alert.alert("Error", "Login failed. Please try again.");
+    throw new Error("Login failed");
   }
   const idToken = res.data.idToken;
   if (!idToken) throw new Error("No idToken");
   const { accessToken } = await GoogleSignin.getTokens();
-  const response = await fetch(`${API_BASE_URL}/api/auth/google`, {
+  const response = await authFetch("/api/auth/google", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ idToken }),
-  });
+  }, 20_000);
   if (!response.ok) {
-    Alert.alert("error logging in")
-    throw new Error("Error logging in");
+    Alert.alert("Error", "Login failed. Please try again.");
+    throw new Error("Login failed");
   }
   const { token } = await response.json();
   return {

--- a/app/src/utils/fetchUtils.ts
+++ b/app/src/utils/fetchUtils.ts
@@ -1,9 +1,33 @@
 import * as Keychain from "react-native-keychain";
 import { API_BASE_URL } from "./utils";
 
-export async function authFetch(path: string, init: RequestInit = {}) {
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export async function authFetch(
+  path: string,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_TIMEOUT_MS
+): Promise<Response> {
   const credentials = await Keychain.getGenericPassword();
   const headers = new Headers(init.headers);
   if (credentials) headers.set("Authorization", `Bearer ${credentials.password}`);
-  return fetch(`${API_BASE_URL}${path}`, { ...init, headers });
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(`${API_BASE_URL}${path}`, {
+      ...init,
+      headers,
+      signal: controller.signal,
+    });
+    return response;
+  } catch (error: any) {
+    if (error.name === "AbortError") {
+      throw new Error("Request timed out. Please check your connection.");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }


### PR DESCRIPTION
## What
Added configurable timeout handling to the authFetch utility function that wraps all API calls in the app.

## Why
Previously, network requests could hang indefinitely if the server didn't respond, leaving the user stuck on a loading state. This change adds:
- A default 15-second timeout for API calls (20 seconds for login which may be slower)
- Clear error messages when requests timeout
- Better user experience on slow or unstable network connections

This is a foundational improvement that benefits all API interactions in the app.