### PR TITLE
[FE-ENG-AGENT] Add cancel button for pending tools

### DIFF
--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -184,6 +184,12 @@ export default function VoiceDashboard2() {
     handleTranscript(text);
   }, [devText, handleTranscript]);
 
+  const handleDismissTool = useCallback(() => {
+    setPendingTool(null);
+    setTool(null);
+    setVoiceListenerState('listening');
+  }, []);
+
   return (
     <View style={styles.root}>
       <View style={styles.topbar}>
@@ -233,6 +239,11 @@ export default function VoiceDashboard2() {
                 <Text style={[styles.kvVal, !v && styles.kvValNull]}>{v ?? 'null'}</Text>
               </View>
             ))}
+            {pendingTool && (
+              <Pressable style={styles.dismissBtn} onPress={handleDismissTool}>
+                <Text style={styles.dismissBtnText}>Cancel</Text>
+              </Pressable>
+            )}
           </View>
         )}
       </View>
@@ -437,6 +448,21 @@ const styles = StyleSheet.create({
   kvValNull: {
     color: 'rgba(229,231,235,0.45)',
     fontStyle: 'italic',
+  },
+  dismissBtn: {
+    marginTop: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: 'rgba(239,68,68,0.4)',
+    backgroundColor: 'rgba(239,68,68,0.1)',
+    alignItems: 'center',
+  },
+  dismissBtnText: {
+    color: '#ef4444',
+    fontSize: 13,
+    fontWeight: '600',
   },
   devInputRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## What
Added a cancel button to the tool panel that appears when a non-silent tool (like sending an email) is pending user confirmation. The button clears the pending tool and returns the app to listening mode.

## Why
Currently, when a pending tool is waiting for user confirmation, there's no way for the user to dismiss or cancel it - they must either confirm or wait for a timeout. This addition allows users to easily cancel a pending action when they change their mind, improving the overall UX of the voice assistant.