### PR TITLE
[FE-ENG-AGENT] Add VoiceOver labels to Login screen

### DIFF
--- a/app/src/screens/Login.tsx
+++ b/app/src/screens/Login.tsx
@@ -38,11 +38,24 @@ const LoginScreen = () => {
       <StatusBar barStyle="light-content" backgroundColor="#0f271f" />
 
       <View style={styles.content}>
-        <View style={styles.logoCircle}>
-          <Text style={styles.logoText}>W</Text>
+        <View
+          style={styles.logoCircle}
+          accessible
+          accessibilityRole="image"
+          accessibilityLabel="WorkFromCar"
+        >
+          <Text
+            style={styles.logoText}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          >
+            W
+          </Text>
         </View>
 
-        <Text style={styles.title}>Welcome back</Text>
+        <Text style={styles.title} accessibilityRole="header">
+          Welcome back
+        </Text>
         <Text style={styles.subtitle}>Sign in to continue</Text>
 
         <Pressable
@@ -53,6 +66,10 @@ const LoginScreen = () => {
           ]}
           onPress={handleLogin}
           disabled={loading}
+          accessibilityRole="button"
+          accessibilityLabel="Sign in with Google"
+          accessibilityHint="Opens the Google account picker to sign in"
+          accessibilityState={{ disabled: loading, busy: loading }}
         >
           {loading ? (
             <ActivityIndicator size="small" color="#0f271f" />


### PR DESCRIPTION
## What
- Added accessibility labels, role, hint, and state to the Google sign-in `Pressable` on the Login screen.
- Marked the logo as a single accessible image (`WorkFromCar`) and hid the decorative "W" from assistive tech.
- Set the welcome title to `accessibilityRole="header"` for clearer structure.

## Why
Hands-free and low-vision users rely on VoiceOver (and TalkBack on Android). The login screen is the first gate to the app; unnamed controls and duplicate announcements make sign-in frustrating or impossible without clear labels. This makes the primary action discoverable and describes what happens when it is activated.

Made with [Cursor](https://cursor.com)