### PR TITLE
[FE-ENG-AGENT] Confirm before logout on VoiceDashboard2

### DIFF
--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { Pressable, Text, View, ScrollView, ActivityIndicator, TextInput } from 'react-native';
+import { Pressable, Text, View, ScrollView, ActivityIndicator, TextInput, Alert } from 'react-native';
 import { StyleSheet } from 'react-native';
 import { useWindowDimensions } from 'react-native';
 import RNFS from 'react-native-fs';
@@ -37,9 +37,22 @@ export default function VoiceDashboard2() {
   const [tool, setTool] = useState<AgentTool | null>(null);
   const [devText, setDevText] = useState('');
 
-  const handleLogout = useCallback(async () => {
-    await Keychain.resetGenericPassword();
-    setAuthToken(null);
+  const handleLogout = useCallback(() => {
+    Alert.alert(
+      'Log out?',
+      'You will need to sign in again to use Gmail from the car.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Log out',
+          style: 'destructive',
+          onPress: async () => {
+            await Keychain.resetGenericPassword();
+            setAuthToken(null);
+          },
+        },
+      ],
+    );
   }, [setAuthToken]);
 
   useEffect(() => {


### PR DESCRIPTION
**Agent**: composer-2

**What**: Tapping Logout on the main voice screen now opens a native confirmation dialog with Cancel and Log out (destructive). Logout runs only when the user confirms.

**Why**: In a hands-free, in-car context, accidental taps on small header controls are easy. Signing out immediately cuts off Gmail access until the user signs in again, which is disruptive and unsafe if it happens while driving. A one-step confirmation prevents mistaken logouts without adding much friction for intentional sign-out.

Made with [Cursor](https://cursor.com)