### PR TITLE
[FE-ENG-AGENT] Listening mic viz + voice mode labels on VoiceDashboard2

### DIFF
--- a/app/src/components/AudioVisualizer.tsx
+++ b/app/src/components/AudioVisualizer.tsx
@@ -38,13 +38,27 @@ export default function AudioVisualizer({ mode = 'disabled' }: Props) {
       smoothedRmsRef.current =
         SMOOTHING * rms + (1 - SMOOTHING) * smoothedRmsRef.current;
 
-      const isSpeaking = modeRef.current === 'speaking';
+      const mode = modeRef.current;
+      const isSpeaking = mode === 'speaking';
+      const isListening = mode === 'listening';
 
       animatedHeights.forEach((anim, i) => {
-        const targetHeight = isSpeaking
-          ? MIN_HEIGHT + (MAX_HEIGHT - MIN_HEIGHT) * Math.min(smoothedRmsRef.current * 12, 1) *
-            (0.5 + 0.5 * Math.sin((Date.now() / 80 + BAR_OFFSETS[i] * 0.01)))
-          : MIN_HEIGHT;
+        let targetHeight = MIN_HEIGHT;
+        if (isSpeaking) {
+          targetHeight =
+            MIN_HEIGHT +
+            (MAX_HEIGHT - MIN_HEIGHT) *
+              Math.min(smoothedRmsRef.current * 12, 1) *
+              (0.5 + 0.5 * Math.sin((Date.now() / 80 + BAR_OFFSETS[i] * 0.01)));
+        } else if (isListening) {
+          const level = Math.min(smoothedRmsRef.current * 10, 1);
+          targetHeight =
+            MIN_HEIGHT +
+            (MAX_HEIGHT - MIN_HEIGHT) *
+              0.28 *
+              level *
+              (0.88 + 0.12 * Math.sin(Date.now() / 240 + i * 0.9));
+        }
 
         Animated.spring(anim, {
           toValue: targetHeight,

--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { Pressable, Text, View, ScrollView, ActivityIndicator, TextInput } from 'react-native';
+import { Pressable, Text, View, ScrollView, ActivityIndicator, TextInput, StatusBar } from 'react-native';
 import { StyleSheet } from 'react-native';
 import { useWindowDimensions } from 'react-native';
 import RNFS from 'react-native-fs';
@@ -23,6 +23,22 @@ const VAD_PATH = `${RNFS.MainBundlePath}/${VAD_FILENAME}`;
 const KOKORO_MODEL_DIR = `${RNFS.MainBundlePath}/sherpa-onnx-kokoro-en-v0_19`;
 
 const DEV_TEXT_MODE = false;
+
+function voiceModeLabel(state: VoiceListenerState, speaking: boolean): string {
+  if (state === 'disabled') {
+    return speaking ? 'Speaking…' : 'Processing…';
+  }
+  switch (state) {
+    case 'listening':
+      return 'Listening…';
+    case 'speaking':
+      return 'Hearing you…';
+    case 'transcribing':
+      return 'Transcribing…';
+    default:
+      return state;
+  }
+}
 
 export default function VoiceDashboard2() {
   const { height } = useWindowDimensions();
@@ -186,6 +202,7 @@ export default function VoiceDashboard2() {
 
   return (
     <View style={styles.root}>
+      <StatusBar barStyle="light-content" backgroundColor="#0f271f" />
       <View style={styles.topbar}>
         <Pressable style={styles.logoutBtn} onPress={handleLogout}>
           <Text style={styles.logoutBtnText}>Logout</Text>
@@ -214,9 +231,7 @@ export default function VoiceDashboard2() {
           : <AudioVisualizer mode={voiceListenerState} />
         }
         <Text style={styles.modeLabel}>
-          {voiceListenerState === 'disabled'
-            ? speaking ? 'Speaking...' : 'Processing...'
-            : voiceListenerState}
+          {voiceModeLabel(voiceListenerState, speaking)}
         </Text>
 
         {tool && (


### PR DESCRIPTION
**Agent**: composer-2

**What**: The main dashboard now shows human-readable voice states (e.g. “Listening…”, “Transcribing…”) instead of raw enum strings. The audio visualizer animates bars when the mic is in the listening state (subtle RMS-based motion), not only while “speaking,” so users get ambient feedback that the mic is live. Added a light StatusBar style to match the dark screen.

**Why**: Hands-free driving use depends on glancing at the phone for confirmation. Clear labels reduce cognitive load; subtle motion during listening shows the pipeline is active before speech is detected, which helps users know when to speak without waiting for silence-to-speech transitions.

Made with [Cursor](https://cursor.com)