### PR TITLE
[FE-ENG-AGENT] Humanize voice status labels and improve dashboard a11y

### DIFF
--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { Pressable, Text, View, ScrollView, ActivityIndicator, TextInput, Alert } from 'react-native';
+import { Pressable, Text, View, ScrollView, ActivityIndicator, TextInput, Alert, StatusBar } from 'react-native';
 import { StyleSheet } from 'react-native';
 import { useWindowDimensions } from 'react-native';
 import RNFS from 'react-native-fs';
@@ -23,6 +23,22 @@ const VAD_PATH = `${RNFS.MainBundlePath}/${VAD_FILENAME}`;
 const KOKORO_MODEL_DIR = `${RNFS.MainBundlePath}/sherpa-onnx-kokoro-en-v0_19`;
 
 const DEV_TEXT_MODE = false;
+
+function voiceModeLabel(state: VoiceListenerState, ttsSpeaking: boolean): string {
+  if (state === 'disabled') {
+    return ttsSpeaking ? 'Speaking...' : 'Processing...';
+  }
+  switch (state) {
+    case 'listening':
+      return 'Listening';
+    case 'transcribing':
+      return 'Transcribing...';
+    case 'speaking':
+      return 'Recording...';
+    default:
+      return state;
+  }
+}
 
 export default function VoiceDashboard2() {
   const { height } = useWindowDimensions();
@@ -211,8 +227,15 @@ export default function VoiceDashboard2() {
 
   return (
     <View style={styles.root}>
+      <StatusBar barStyle="light-content" backgroundColor="#0f271f" />
       <View style={styles.topbar}>
-        <Pressable style={styles.logoutBtn} onPress={handleLogout}>
+        <Pressable
+          style={styles.logoutBtn}
+          onPress={handleLogout}
+          accessibilityRole="button"
+          accessibilityLabel="Log out"
+          accessibilityHint="Sign out and return to the login screen"
+        >
           <Text style={styles.logoutBtnText}>Logout</Text>
         </Pressable>
         {modelStatus !== 'ready' && (
@@ -238,10 +261,8 @@ export default function VoiceDashboard2() {
           ? <ActivityIndicator size="large" color="#e8fff6" style={{ height: 150 }} />
           : <AudioVisualizer mode={voiceListenerState} />
         }
-        <Text style={styles.modeLabel}>
-          {voiceListenerState === 'disabled'
-            ? speaking ? 'Speaking...' : 'Processing...'
-            : voiceListenerState}
+        <Text style={styles.modeLabel} accessibilityLiveRegion="polite">
+          {voiceModeLabel(voiceListenerState, speaking)}
         </Text>
 
         {tool && (


### PR DESCRIPTION
**Agent**: composer-2

**What**: Updated `VoiceDashboard2` to show plain-language status text (Listening, Recording…, Transcribing…) instead of raw internal state strings; matched the login screen with a light `StatusBar`; added VoiceOver-friendly labels and a polite live region on the status line for the logout control.

**Why**: Hands-free driving use depends on glancing at clear, non-technical feedback. Readable labels and accessibility hooks reduce cognitive load and help screen-reader users follow assistant state without hearing cryptic enum names.

Made with [Cursor](https://cursor.com)