### PR TITLE
[AGENT] Restart voice capture when app returns to foreground

### DIFF
--- a/app/src/components/VoiceListener.tsx
+++ b/app/src/components/VoiceListener.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Text, StyleSheet, View } from "react-native";
+import { Text, StyleSheet, View, AppState, type AppStateStatus } from "react-native";
 import { startVadStreaming, stopVadStreaming } from "../services/audio/voiceProcessor";
 import NativeWhisper from 'whisper/src/NativeWhisper';
 
@@ -21,6 +21,18 @@ export default function VoiceListener({ state, onStateChange, onTranscript }: Pr
   const [prob, setProb] = useState<string>('');
 
   const isActive = state !== 'disabled';
+  const [foregroundEpoch, setForegroundEpoch] = useState(0);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const onAppStateChange = (next: AppStateStatus) => {
+      if (next === "active") {
+        setForegroundEpoch((n) => n + 1);
+      }
+    };
+    const sub = AppState.addEventListener("change", onAppStateChange);
+    return () => sub.remove();
+  }, [isActive]);
 
   useEffect(() => { stateRef.current = state; }, [state]);
   useEffect(() => { onStateChangeRef.current = onStateChange; }, [onStateChange]);
@@ -119,7 +131,7 @@ export default function VoiceListener({ state, onStateChange, onTranscript }: Pr
       isMounted = false;
       stopVadStreaming();
     };
-  }, [isActive]);
+  }, [isActive, foregroundEpoch]);
   return (
     <View style={styles.content}>
       <Text style={styles.text}>


### PR DESCRIPTION
## What

When the app comes back to the foreground while voice listening is enabled, `VoiceListener` now tears down and restarts Picovoice `VoiceProcessor` streaming (via a dependency on a `foregroundEpoch` counter bumped on `AppState` `active`).

## Why

On iOS, leaving the app typically stops or invalidates the active audio capture session. The VAD/mic effect only depended on `isActive` (`state !== 'disabled'`), so after backgrounding and returning it never re-ran and the mic stayed silent even though the UI still showed listening.

## Testing

- `npx tsc --noEmit` in `app/` (project has pre-existing TS issues in this file and local packages; no new errors from this change).
- Manual: open voice screen, background the app, return, confirm speech is detected again.

Made with [Cursor](https://cursor.com)