### PR TITLE
[AGENT] Avoid login screen flash when already signed in

### DIFF
--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -1,14 +1,13 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useEffect, useState } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import * as Keychain from "react-native-keychain";
 
 import LoginScreen from '../screens/Login';
-import VoiceDashboardScreen from '../screens/VoiceDashboard';
 import VoiceDashboardScreen2 from '../screens/VoiceDashboard2';
 import { useAccessToken } from '../context/AccessTokenContext';
 import { silentLogin } from '../api/auth';
-import DemoScreen from '../screens/Demo';
 
 
 type RootStackParamList = {
@@ -21,25 +20,36 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export const RootNavigator = () => {
   const { authToken, setAuthToken } = useAccessToken();
-  const [hasJwt, setHasJwt] = useState<boolean | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
 
   useEffect(() => {
     const checkAuth = async () => {
-      const credentials = await Keychain.getGenericPassword();
-      const jwtExists = !!credentials;
-      setHasJwt(jwtExists);
+      try {
+        const credentials = await Keychain.getGenericPassword();
+        const jwtExists = !!credentials;
 
-      if (jwtExists && !authToken) {
-        const token = await silentLogin();
-        if (token) {
-          setAuthToken(token);
+        if (jwtExists) {
+          const token = await silentLogin();
+          if (token) {
+            setAuthToken(token);
+          }
         }
+      } finally {
+        setAuthChecked(true);
       }
     };
     checkAuth();
-  }, []);
+  }, [setAuthToken]);
 
   const isAuthed = !!authToken;
+
+  if (!authChecked) {
+    return (
+      <View style={styles.bootSplash}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
 
   return (
     <NavigationContainer>
@@ -61,5 +71,13 @@ export const RootNavigator = () => {
     </NavigationContainer>
   )
 }
+
+const styles = StyleSheet.create({
+  bootSplash: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
 
 export default RootNavigator;


### PR DESCRIPTION
## What
Gate the root navigator on an initial auth bootstrap: until keychain is read and optional `silentLogin` completes, show a minimal full-screen spinner instead of the Login stack. Removed unused navigator imports.

## Why
On cold start, `authToken` is null until async work finishes, so the UI briefly rendered Login even for users with a stored JWT. Waiting for that check removes the flash and matches the user’s signed-in state.

Made with [Cursor](https://cursor.com)