### PR TITLE
[AGENT] Inject date context into planner messages

### DIFF
--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -26,6 +26,22 @@ const VAD_PATH = `${RNFS.MainBundlePath}/${VAD_FILENAME}`;
 const KOKORO_MODEL_DIR = `${RNFS.MainBundlePath}/sherpa-onnx-kokoro-en-v0_19`;
 
 const DEV_TEXT_MODE = true;
+const DATE_CONTEXT_PREFIX = 'Current local time:';
+
+function buildDateContextMessage(): Message {
+  const now = new Date();
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  return {
+    role: 'system',
+    content: `${DATE_CONTEXT_PREFIX} ${now.toISOString()} (${timeZone}). Today is ${now.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })}.`,
+  };
+}
 
 export default function VoiceDashboard2() {
   const { height } = useWindowDimensions();
@@ -166,8 +182,12 @@ export default function VoiceDashboard2() {
   const handleTranscript = useCallback(async (text: string) => {
     if (!DEV_TEXT_MODE) setVoiceListenerState('disabled');
     try {
+      const dateContext = buildDateContextMessage();
       const userMessage: Message = { role: 'user', content: text.trim() };
-      let currentMessages = [...messages, userMessage];
+      const priorMessages = messages.filter((message) => (
+        !(message.role === 'system' && message.content.startsWith(DATE_CONTEXT_PREFIX))
+      ));
+      let currentMessages = [dateContext, ...priorMessages, userMessage];
       setMessages([...currentMessages]);
 
       const result = await sendAgentMessage(currentMessages, pendingTool);


### PR DESCRIPTION
## What
- Inject a fresh system message with the current local ISO timestamp, IANA timezone, and human-readable date at the start of `handleTranscript` planner messages in `app/src/screens/VoiceDashboard2.tsx`.
- Remove any prior injected date-context system messages before prepending the new one so the planner always sees one fresh date reference instead of stale duplicates.

## Why
- The planner needs the actual current date and timezone to resolve relative phrases like tomorrow or next Thursday correctly for calendar actions.
- Refreshing the context on every transcript keeps long sessions accurate and prevents the model from reasoning from outdated time information.

## Verification
- Ran `npx tsc --noEmit` in `app` and found pre-existing TypeScript errors in `src/components/VoiceListener.tsx` and `packages/{kokoro,whisper}` unrelated to this change.
- Ran `npx eslint src/screens/VoiceDashboard2.tsx` and saw only pre-existing issues in that file unrelated to the date-context edit.

Made with [Cursor](https://cursor.com)