### PR TITLE
[AGENT] Add gcal.getEvents silent tool

### DIFF
--- a/app/src/api/gcalGetEvents.ts
+++ b/app/src/api/gcalGetEvents.ts
@@ -1,0 +1,59 @@
+export const GCAL_EVENTS_BASE = 'https://www.googleapis.com/calendar/v3/calendars/primary/events';
+
+export interface CalendarEventSummary {
+  summary: string;
+  start: string | null;
+  end: string | null;
+  location: string | null;
+  attendees: string[];
+}
+
+export async function getEvents({
+  accessToken,
+  timeMin,
+  timeMax,
+  maxResults,
+}: {
+  accessToken: string;
+  timeMin: string;
+  timeMax: string;
+  maxResults: number | null;
+}): Promise<CalendarEventSummary[]> {
+  const limit = maxResults ?? 10;
+  const eventsUrl = new URL(GCAL_EVENTS_BASE);
+  eventsUrl.searchParams.set('timeMin', timeMin);
+  eventsUrl.searchParams.set('timeMax', timeMax);
+  eventsUrl.searchParams.set('maxResults', String(limit));
+  eventsUrl.searchParams.set('singleEvents', 'true');
+  eventsUrl.searchParams.set('orderBy', 'startTime');
+
+  const res = await fetch(eventsUrl.toString(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('[gcal.getEvents] error response', {
+      status: res.status,
+      statusText: res.statusText,
+      body: text,
+      timeMin,
+      timeMax,
+      maxResults: limit,
+    });
+    throw new Error(`Failed to get events: ${res.status} ${text}`);
+  }
+
+  const data = await res.json();
+  const events = data.items ?? [];
+
+  return events.map((event: any) => ({
+    summary: event.summary ?? 'Untitled event',
+    start: event.start?.dateTime ?? event.start?.date ?? null,
+    end: event.end?.dateTime ?? event.end?.date ?? null,
+    location: event.location ?? null,
+    attendees: (event.attendees ?? []).map((attendee: any) => attendee.email).filter(Boolean),
+  }));
+}

--- a/app/src/api/toolExecutor.ts
+++ b/app/src/api/toolExecutor.ts
@@ -6,8 +6,9 @@ import { replyEmail } from "./replyEmail";
 import { forwardEmail } from "./forwardEmail";
 import { summarizeEmails } from "./summarizeEmails";
 import { emailCreateDraftSchema, resolveContactParametersSchema, emailSummarizeParametersSchema, readEmailParametersSchema, emailReplyParametersSchema, emailForwardParametersSchema } from "./toolSchemas/email";
-import { gcalCreateEventSchema } from "./toolSchemas/gcal";
+import { gcalCreateEventSchema, gcalGetEventsSchema } from "./toolSchemas/gcal";
 import { createEvent } from "./gcalCreateEvent";
+import { getEvents } from "./gcalGetEvents";
 
 export async function executeTool(tool: AgentTool, accessToken: string): Promise<ToolExecutionLog> {
   switch (tool.tool) {
@@ -73,6 +74,19 @@ export async function executeTool(tool: AgentTool, accessToken: string): Promise
         return { tool: tool.tool, status: 'success', result };
       } catch (e: any) {
         console.error('[executeTool] gcal.createEvent failed', {
+          toolParameters: tool.toolParameters,
+          message: e?.message,
+        });
+        return { tool: tool.tool, status: 'error', result: { message: e.message } };
+      }
+    }
+    case 'gcal.getEvents': {
+      try {
+        const params = gcalGetEventsSchema.parse(tool.toolParameters);
+        const result = await getEvents({ ...params, accessToken });
+        return { tool: tool.tool, status: 'success', result };
+      } catch (e: any) {
+        console.error('[executeTool] gcal.getEvents failed', {
           toolParameters: tool.toolParameters,
           message: e?.message,
         });

--- a/app/src/api/toolSchemas/gcal.ts
+++ b/app/src/api/toolSchemas/gcal.ts
@@ -9,3 +9,9 @@ export const gcalCreateEventSchema = z.object({
   description: z.string().nullable(),
   attendees: z.array(z.string()).nullable(),
 });
+
+export const gcalGetEventsSchema = z.object({
+  timeMin: z.string(),
+  timeMax: z.string(),
+  maxResults: z.number().nullable(),
+});

--- a/app/src/components/ToolIndicator.tsx
+++ b/app/src/components/ToolIndicator.tsx
@@ -17,6 +17,7 @@ const TOOL_ICONS: Record<string, React.ReactElement> = {
   'gmail.replyToEmail':    <EmailLogo size={ICON_SIZE} color={ICON_COLOR} />,
   'gmail.forwardEmail':    <EmailLogo size={ICON_SIZE} color={ICON_COLOR} />,
   'gcal.createEvent':      <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
+  'gcal.getEvents':        <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
 };
 
 function ToolIcon({ toolName }: { toolName: string }) {
@@ -31,6 +32,7 @@ const TOOL_LABELS: Record<string, string> = {
   'gmail.replyToEmail': 'Inbox',
   'gmail.forwardEmail': 'Inbox',
   'gcal.createEvent': 'Calendar',
+  'gcal.getEvents': 'Calendar',
 };
 
 interface Props {

--- a/server/src/api/Agent/actions/PlanActions.ts
+++ b/server/src/api/Agent/actions/PlanActions.ts
@@ -11,6 +11,7 @@ import { emailReadParametersSchema } from "../tools/gmail/EmailRead";
 import { emailReplyParametersSchema } from "../tools/gmail/EmailReply";
 import { emailForwardParametersSchema } from "../tools/gmail/EmailForward";
 import { gcalCreateEventParametersSchema } from "../tools/gcal/GcalCreateEvent";
+import { gcalGetEventsParametersSchema } from "../tools/gcal/GcalGetEvents";
 
 function formatZodError(err: any): string {
   if (err?.issues && Array.isArray(err.issues)) {
@@ -100,6 +101,9 @@ export const verifyLLMToolCall = (plan: LLMPlanResponse) => {
       return;
     case "gcal.createEvent":
       plan.toolParameters = gcalCreateEventParametersSchema.parse(plan.toolParameters);
+      return;
+    case "gcal.getEvents":
+      plan.toolParameters = gcalGetEventsParametersSchema.parse(plan.toolParameters);
       return;
   }
 };

--- a/server/src/api/Agent/tools/gcal/GcalGetEvents.ts
+++ b/server/src/api/Agent/tools/gcal/GcalGetEvents.ts
@@ -1,0 +1,39 @@
+import * as z from "zod";
+
+export type gcalGetEventsParameters = {
+  timeMin: string;
+  timeMax: string;
+  maxResults: number | null;
+};
+
+export const gcalGetEventsParametersSchema = z.object({
+  timeMin: z.string(),
+  timeMax: z.string(),
+  maxResults: z.number().nullable(),
+}) satisfies z.ZodType<gcalGetEventsParameters>;
+
+export const GCAL_GET_EVENTS_INSTRUCTIONS = `
+  1. "gcal.getEvents"
+  Use this tool when the user asks about their agenda, schedule, upcoming events, or what is on their calendar.
+  This is a SILENT tool. Do not ask for confirmation before using it. Call it immediately when the user is asking to check their calendar.
+  When you decide to use this tool, output JSON with:
+  - tool: "gcal.getEvents"
+  - toolParameters:
+    - timeMin: string — the start of the requested range in ISO 8601 format with UTC offset, e.g. "2026-03-31T00:00:00-04:00"
+    - timeMax: string — the end of the requested range in ISO 8601 format with UTC offset
+    - maxResults: number | null — how many events to fetch. Default to 10 if null.
+
+  Derive timeMin and timeMax from natural language relative to today's date:
+  - "today": start of today through end of today
+  - "tomorrow": start of tomorrow through end of tomorrow
+  - "this week": start of the current week through end of the current week
+  - "next week": start of next week through end of next week
+  - "this afternoon" or "this evening": use the corresponding time window today
+  - If the user gives specific dates or times, convert them into an exact ISO 8601 range.
+
+  Both timeMin and timeMax MUST be non-null strings. Never emit null for either field.
+  After receiving the result:
+  - Summarize the events in chronological order.
+  - Mention the title, time, and location when useful.
+  - If no events are returned, tell the user their calendar is clear for that time range.
+`;

--- a/server/src/api/Agent/utils/AgentToolSpec.ts
+++ b/server/src/api/Agent/utils/AgentToolSpec.ts
@@ -5,6 +5,7 @@ import { EMAIL_READ_INSTRUCTIONS } from "../tools/gmail/EmailRead";
 import { EMAIL_REPLY_INSTRUCTIONS } from "../tools/gmail/EmailReply";
 import { EMAIL_FORWARD_INSTRUCTIONS } from "../tools/gmail/EmailForward";
 import { GCAL_CREATE_EVENT_INSTRUCTIONS } from "../tools/gcal/GcalCreateEvent";
+import { GCAL_GET_EVENTS_INSTRUCTIONS } from "../tools/gcal/GcalGetEvents";
 
 export const ALL_TOOLS_DESCRIPTION = `
   ${EMAIL_CREATE_DRAFT_INSTRUCTIONS}\n
@@ -13,5 +14,6 @@ export const ALL_TOOLS_DESCRIPTION = `
   ${EMAIL_READ_INSTRUCTIONS}\n
   ${EMAIL_REPLY_INSTRUCTIONS}\n
   ${EMAIL_FORWARD_INSTRUCTIONS}\n
-  ${GCAL_CREATE_EVENT_INSTRUCTIONS}
+  ${GCAL_CREATE_EVENT_INSTRUCTIONS}\n
+  ${GCAL_GET_EVENTS_INSTRUCTIONS}
   `;

--- a/server/src/api/Agent/utils/isSilent.test.ts
+++ b/server/src/api/Agent/utils/isSilent.test.ts
@@ -9,6 +9,10 @@ describe('isSilent()', () => {
     expect(isSilent({ tool: "gmail.summarizeEmails", toolParameters: null })).toBe(true);
   });
 
+  it("returns true for gcal.getEvents", () => {
+    expect(isSilent({ tool: "gcal.getEvents", toolParameters: null })).toBe(true);
+  });
+
   it("returns false for gmail.createDraft", () => {
     expect(isSilent({ tool: "gmail.createDraft", toolParameters: null })).toBe(false);
   });

--- a/server/src/api/Agent/utils/isSilent.ts
+++ b/server/src/api/Agent/utils/isSilent.ts
@@ -6,6 +6,7 @@ export const isSilent = (call: AgentTool) => {
     case "gmail.resolveContact":
     case "gmail.summarizeEmails":
     case "gmail.readEmail":
+    case "gcal.getEvents":
       return true;
     default:
       return false;


### PR DESCRIPTION
## What
- add a new silent `gcal.getEvents` planner tool definition and register it in the server tool spec
- add the client Google Calendar `events.list` executor path plus shared Zod schema wiring
- mark the tool as silent, surface it in the tool indicator UI, and add a focused `isSilent` test

## Why
- this lets the assistant answer agenda and schedule questions by fetching calendar events automatically, without forcing an unnecessary confirmation step
- wiring the tool through both planner validation and client execution keeps calendar lookup consistent with the existing silent Gmail tool flow

## Test Plan
- `cd server && npx jest --config src/jest.config.js src/api/Agent/utils/isSilent.test.ts`
- `cd app && npx tsc --noEmit` *(fails due to pre-existing repo issues in `VoiceListener.tsx` and local package React Native module typings)*
- `cd server && npx tsc --noEmit` *(fails due to pre-existing repo issues resolving `jsonrepair`, `openai`, and `@koa/cors` typings)*

Made with [Cursor](https://cursor.com)