### PR TITLE
[AGENT] Add gcal.respondToEvent tool

### DIFF
--- a/app/src/api/gcalGetEvents.ts
+++ b/app/src/api/gcalGetEvents.ts
@@ -1,11 +1,13 @@
 export const GCAL_EVENTS_BASE = 'https://www.googleapis.com/calendar/v3/calendars/primary/events';
 
 export interface CalendarEventSummary {
+  id: string;
   summary: string;
   start: string | null;
   end: string | null;
   location: string | null;
   attendees: string[];
+  selfResponseStatus: string | null;
 }
 
 export async function getEvents({
@@ -50,10 +52,12 @@ export async function getEvents({
   const events = data.items ?? [];
 
   return events.map((event: any) => ({
+    id: event.id,
     summary: event.summary ?? 'Untitled event',
     start: event.start?.dateTime ?? event.start?.date ?? null,
     end: event.end?.dateTime ?? event.end?.date ?? null,
     location: event.location ?? null,
     attendees: (event.attendees ?? []).map((attendee: any) => attendee.email).filter(Boolean),
+    selfResponseStatus: event.attendees?.find((attendee: any) => attendee?.self)?.responseStatus ?? null,
   }));
 }

--- a/app/src/api/gcalRespondToEvent.ts
+++ b/app/src/api/gcalRespondToEvent.ts
@@ -1,0 +1,91 @@
+const GCAL_EVENTS_BASE = 'https://www.googleapis.com/calendar/v3/calendars/primary/events';
+
+type CalendarEventAttendee = {
+  email?: string;
+  displayName?: string;
+  organizer?: boolean;
+  self?: boolean;
+  resource?: boolean;
+  optional?: boolean;
+  responseStatus?: 'needsAction' | 'accepted' | 'tentative' | 'declined';
+  comment?: string;
+  additionalGuests?: number;
+};
+
+export async function respondToEvent({
+  accessToken,
+  eventId,
+  responseStatus,
+}: {
+  accessToken: string;
+  eventId: string;
+  responseStatus: 'accepted' | 'tentative' | 'declined';
+}) {
+  const eventUrl = `${GCAL_EVENTS_BASE}/${encodeURIComponent(eventId)}`;
+
+  const eventRes = await fetch(eventUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!eventRes.ok) {
+    const text = await eventRes.text();
+    console.error('[gcal.respondToEvent] failed to fetch event', {
+      status: eventRes.status,
+      statusText: eventRes.statusText,
+      body: text,
+      eventId,
+    });
+    throw new Error(`Failed to fetch event: ${eventRes.status} ${text}`);
+  }
+
+  const event = await eventRes.json();
+  const attendees: CalendarEventAttendee[] = event.attendees ?? [];
+  const selfAttendeeIndex = attendees.findIndex((attendee) => attendee?.self);
+
+  if (selfAttendeeIndex === -1) {
+    throw new Error('Could not find your attendee record for this event.');
+  }
+
+  const updatedAttendees = attendees.map((attendee, index) => (
+    index === selfAttendeeIndex
+      ? { ...attendee, responseStatus }
+      : attendee
+  ));
+
+  const updateUrl = `${eventUrl}?sendUpdates=none`;
+  const updateRes = await fetch(updateUrl, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      attendees: updatedAttendees,
+    }),
+  });
+
+  if (!updateRes.ok) {
+    const text = await updateRes.text();
+    console.error('[gcal.respondToEvent] failed to update response', {
+      status: updateRes.status,
+      statusText: updateRes.statusText,
+      body: text,
+      eventId,
+      responseStatus,
+    });
+    throw new Error(`Failed to respond to event: ${updateRes.status} ${text}`);
+  }
+
+  const updatedEvent = await updateRes.json();
+
+  return {
+    success: true,
+    eventId: updatedEvent.id,
+    summary: updatedEvent.summary ?? event.summary ?? 'Untitled event',
+    start: updatedEvent.start?.dateTime ?? updatedEvent.start?.date ?? event.start?.dateTime ?? event.start?.date ?? null,
+    responseStatus,
+    htmlLink: updatedEvent.htmlLink ?? event.htmlLink ?? null,
+  };
+}

--- a/app/src/api/toolExecutor.ts
+++ b/app/src/api/toolExecutor.ts
@@ -6,9 +6,10 @@ import { replyEmail } from "./replyEmail";
 import { forwardEmail } from "./forwardEmail";
 import { summarizeEmails } from "./summarizeEmails";
 import { emailCreateDraftSchema, resolveContactParametersSchema, emailSummarizeParametersSchema, readEmailParametersSchema, emailReplyParametersSchema, emailForwardParametersSchema } from "./toolSchemas/email";
-import { gcalCreateEventSchema, gcalGetEventsSchema } from "./toolSchemas/gcal";
+import { gcalCreateEventSchema, gcalGetEventsSchema, gcalRespondToEventSchema } from "./toolSchemas/gcal";
 import { createEvent } from "./gcalCreateEvent";
 import { getEvents } from "./gcalGetEvents";
+import { respondToEvent } from "./gcalRespondToEvent";
 
 export async function executeTool(tool: AgentTool, accessToken: string): Promise<ToolExecutionLog> {
   switch (tool.tool) {
@@ -87,6 +88,23 @@ export async function executeTool(tool: AgentTool, accessToken: string): Promise
         return { tool: tool.tool, status: 'success', result };
       } catch (e: any) {
         console.error('[executeTool] gcal.getEvents failed', {
+          toolParameters: tool.toolParameters,
+          message: e?.message,
+        });
+        return { tool: tool.tool, status: 'error', result: { message: e.message } };
+      }
+    }
+    case 'gcal.respondToEvent': {
+      try {
+        const params = gcalRespondToEventSchema.parse(tool.toolParameters);
+        const result = await respondToEvent({
+          accessToken,
+          eventId: params.eventId,
+          responseStatus: params.responseStatus,
+        });
+        return { tool: tool.tool, status: 'success', result };
+      } catch (e: any) {
+        console.error('[executeTool] gcal.respondToEvent failed', {
           toolParameters: tool.toolParameters,
           message: e?.message,
         });

--- a/app/src/api/toolSchemas/gcal.ts
+++ b/app/src/api/toolSchemas/gcal.ts
@@ -15,3 +15,10 @@ export const gcalGetEventsSchema = z.object({
   timeMax: z.string(),
   maxResults: z.number().nullable(),
 });
+
+export const gcalRespondToEventSchema = z.object({
+  eventId: z.string(),
+  responseStatus: z.enum(['accepted', 'tentative', 'declined']),
+  summary: z.string().nullable(),
+  start: z.string().nullable(),
+});

--- a/app/src/components/ToolIndicator.tsx
+++ b/app/src/components/ToolIndicator.tsx
@@ -18,6 +18,7 @@ const TOOL_ICONS: Record<string, React.ReactElement> = {
   'gmail.forwardEmail':    <EmailLogo size={ICON_SIZE} color={ICON_COLOR} />,
   'gcal.createEvent':      <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
   'gcal.getEvents':        <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
+  'gcal.respondToEvent':   <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
 };
 
 function ToolIcon({ toolName }: { toolName: string }) {
@@ -33,6 +34,7 @@ const TOOL_LABELS: Record<string, string> = {
   'gmail.forwardEmail': 'Inbox',
   'gcal.createEvent': 'Calendar',
   'gcal.getEvents': 'Calendar',
+  'gcal.respondToEvent': 'Calendar',
 };
 
 interface Props {

--- a/app/src/utils/isToolReadyForExecution.ts
+++ b/app/src/utils/isToolReadyForExecution.ts
@@ -4,7 +4,7 @@ import {
   emailForwardParametersSchema,
   emailReplyParametersSchema,
 } from '../api/toolSchemas/email';
-import { gcalCreateEventSchema } from '../api/toolSchemas/gcal';
+import { gcalCreateEventSchema, gcalRespondToEventSchema } from '../api/toolSchemas/gcal';
 import * as z from 'zod';
 
 const EXECUTABLE_TOOL_SCHEMAS: Record<string, z.ZodTypeAny> = {
@@ -12,6 +12,7 @@ const EXECUTABLE_TOOL_SCHEMAS: Record<string, z.ZodTypeAny> = {
   'gmail.replyToEmail': emailReplyParametersSchema,
   'gmail.forwardEmail': emailForwardParametersSchema,
   'gcal.createEvent': gcalCreateEventSchema,
+  'gcal.respondToEvent': gcalRespondToEventSchema,
 };
 
 export function isToolReadyForExecution(tool: AgentTool | null | undefined): boolean {

--- a/server/src/api/Agent/actions/ExecutePermissionsActions.ts
+++ b/server/src/api/Agent/actions/ExecutePermissionsActions.ts
@@ -8,6 +8,7 @@ import { SUMMARY_INSTRUCTION, SUMMARY_JSON_SCHEMA_SCHEMA } from "../utils/Summar
 import { emailReplyParametersSchema } from "../tools/gmail/EmailReply";
 import { emailForwardParametersSchema } from "../tools/gmail/EmailForward";
 import { gcalCreateEventParametersSchema } from "../tools/gcal/GcalCreateEvent";
+import { gcalRespondToEventExecutableParametersSchema } from "../tools/gcal/GcalRespondToEvent";
 
 export async function validateToolCall(tool: AgentTool): Promise<void>{
   switch (tool.tool) {
@@ -22,6 +23,9 @@ export async function validateToolCall(tool: AgentTool): Promise<void>{
       return;
     case 'gcal.createEvent':
       gcalCreateEventParametersSchema.parse(tool.toolParameters);
+      return;
+    case 'gcal.respondToEvent':
+      gcalRespondToEventExecutableParametersSchema.parse(tool.toolParameters);
       return;
     default:
       throw new Error(`Unsupported tool: ${tool.tool}`);

--- a/server/src/api/Agent/actions/PlanActions.ts
+++ b/server/src/api/Agent/actions/PlanActions.ts
@@ -12,6 +12,7 @@ import { emailReplyParametersSchema } from "../tools/gmail/EmailReply";
 import { emailForwardParametersSchema } from "../tools/gmail/EmailForward";
 import { gcalCreateEventParametersSchema } from "../tools/gcal/GcalCreateEvent";
 import { gcalGetEventsParametersSchema } from "../tools/gcal/GcalGetEvents";
+import { gcalRespondToEventParametersSchema } from "../tools/gcal/GcalRespondToEvent";
 
 function formatZodError(err: any): string {
   if (err?.issues && Array.isArray(err.issues)) {
@@ -104,6 +105,9 @@ export const verifyLLMToolCall = (plan: LLMPlanResponse) => {
       return;
     case "gcal.getEvents":
       plan.toolParameters = gcalGetEventsParametersSchema.parse(plan.toolParameters);
+      return;
+    case "gcal.respondToEvent":
+      plan.toolParameters = gcalRespondToEventParametersSchema.parse(plan.toolParameters);
       return;
   }
 };

--- a/server/src/api/Agent/tools/gcal/GcalGetEvents.ts
+++ b/server/src/api/Agent/tools/gcal/GcalGetEvents.ts
@@ -14,7 +14,7 @@ export const gcalGetEventsParametersSchema = z.object({
 
 export const GCAL_GET_EVENTS_INSTRUCTIONS = `
   1. "gcal.getEvents"
-  Use this tool when the user asks about their agenda, schedule, upcoming events, or what is on their calendar.
+  Use this tool when the user asks about their agenda, schedule, upcoming events, what is on their calendar, or when you need to identify an existing calendar event before using gcal.respondToEvent.
   This is a SILENT tool. Do not ask for confirmation before using it. Call it immediately when the user is asking to check their calendar.
   When you decide to use this tool, output JSON with:
   - tool: "gcal.getEvents"
@@ -35,5 +35,7 @@ export const GCAL_GET_EVENTS_INSTRUCTIONS = `
   After receiving the result:
   - Summarize the events in chronological order.
   - Mention the title, time, and location when useful.
+  - When the user is trying to RSVP to an event, use the returned event id, title, and start time to continue with gcal.respondToEvent.
+  - If more than one returned event could match the user's request, ask a clarifying question instead of guessing.
   - If no events are returned, tell the user their calendar is clear for that time range.
 `;

--- a/server/src/api/Agent/tools/gcal/GcalRespondToEvent.ts
+++ b/server/src/api/Agent/tools/gcal/GcalRespondToEvent.ts
@@ -1,0 +1,42 @@
+import * as z from "zod";
+
+export type gcalRespondToEventParameters = {
+  eventId: string | null;
+  responseStatus: 'accepted' | 'tentative' | 'declined' | null;
+  summary: string | null;
+  start: string | null;
+};
+
+export const gcalRespondToEventParametersSchema = z.object({
+  eventId: z.string().nullable(),
+  responseStatus: z.enum(['accepted', 'tentative', 'declined']).nullable(),
+  summary: z.string().nullable(),
+  start: z.string().nullable(),
+}) satisfies z.ZodType<gcalRespondToEventParameters>;
+
+export const gcalRespondToEventExecutableParametersSchema = z.object({
+  eventId: z.string(),
+  responseStatus: z.enum(['accepted', 'tentative', 'declined']),
+  summary: z.string().nullable(),
+  start: z.string().nullable(),
+});
+
+export const GCAL_RESPOND_TO_EVENT_INSTRUCTIONS = `
+  1. "gcal.respondToEvent"
+  Use this tool when the user wants to RSVP to an existing Google Calendar event, such as accepting, declining, or marking an invite as maybe/tentative.
+  If the event is not already clearly identified in the conversation, use gcal.getEvents first to find the relevant event before continuing to this tool.
+  When you decide to use this tool, output JSON with:
+  - assistantMessage (string) — a brief spoken confirmation of the event and RSVP you are about to record
+  - tool: "gcal.respondToEvent"
+  - toolParameters:
+    - eventId: string | null — the Google Calendar event id from a prior gcal.getEvents result. NEVER invent or guess this value.
+    - responseStatus: "accepted" | "tentative" | "declined" | null — map "yes/accept" to "accepted", "maybe" to "tentative", and "no/decline" to "declined".
+    - summary: string | null — the matching event title from gcal.getEvents when available, for confirmation to the user.
+    - start: string | null — the matching event start time from gcal.getEvents when available, for confirmation to the user.
+
+  If there are multiple plausible events, ask the user to clarify which one they mean and keep gcal.respondToEvent as the current tool with the responseStatus filled in if known.
+  This tool is NOT silent. Before calling it, confirm the event title, time, and RSVP back to the user in natural language. Only call the tool once the user has confirmed.
+  When you see the gcal.respondToEvent result in the conversation:
+  - Confirm that the RSVP was updated successfully.
+  - Mention the event title and the new RSVP status in natural language.
+`;

--- a/server/src/api/Agent/utils/AgentToolSpec.ts
+++ b/server/src/api/Agent/utils/AgentToolSpec.ts
@@ -6,6 +6,7 @@ import { EMAIL_REPLY_INSTRUCTIONS } from "../tools/gmail/EmailReply";
 import { EMAIL_FORWARD_INSTRUCTIONS } from "../tools/gmail/EmailForward";
 import { GCAL_CREATE_EVENT_INSTRUCTIONS } from "../tools/gcal/GcalCreateEvent";
 import { GCAL_GET_EVENTS_INSTRUCTIONS } from "../tools/gcal/GcalGetEvents";
+import { GCAL_RESPOND_TO_EVENT_INSTRUCTIONS } from "../tools/gcal/GcalRespondToEvent";
 
 export const ALL_TOOLS_DESCRIPTION = `
   ${EMAIL_CREATE_DRAFT_INSTRUCTIONS}\n
@@ -15,5 +16,6 @@ export const ALL_TOOLS_DESCRIPTION = `
   ${EMAIL_REPLY_INSTRUCTIONS}\n
   ${EMAIL_FORWARD_INSTRUCTIONS}\n
   ${GCAL_CREATE_EVENT_INSTRUCTIONS}\n
-  ${GCAL_GET_EVENTS_INSTRUCTIONS}
+  ${GCAL_GET_EVENTS_INSTRUCTIONS}\n
+  ${GCAL_RESPOND_TO_EVENT_INSTRUCTIONS}
   `;

--- a/server/src/api/Agent/utils/isSilent.test.ts
+++ b/server/src/api/Agent/utils/isSilent.test.ts
@@ -17,6 +17,10 @@ describe('isSilent()', () => {
     expect(isSilent({ tool: "gmail.createDraft", toolParameters: null })).toBe(false);
   });
 
+  it("returns false for gcal.respondToEvent", () => {
+    expect(isSilent({ tool: "gcal.respondToEvent", toolParameters: null })).toBe(false);
+  });
+
   it("returns false for an unknown tool", () => {
     expect(isSilent({ tool: "unknown.tool", toolParameters: null })).toBe(false);
   });


### PR DESCRIPTION
## What
- add a new non-silent gcal.respondToEvent tool so the agent can accept, decline, or tentatively respond to existing Google Calendar invites
- extend gcal.getEvents results and planner instructions so RSVP flows can resolve an event id before confirmation and execution
- wire the new tool through client execution, server planning and validation, tool readiness, and tool UI metadata

## Why
The calendar tool surface could create events and read schedules, but it could not act on existing invites. This closes that gap so calendar RSVP becomes a first-class voice action instead of overloading event creation or depending on manual follow-up outside the app.

## Test plan
- [x] Run server test: npm test -- --runInBand isSilent.test.ts
- [x] Run git diff --check
- [ ] Run app typecheck: npx tsc --noEmit (currently fails on pre-existing VoiceListener implicit any errors and missing react-native type resolution in local packages)
- [ ] Run server typecheck: npx tsc --noEmit (currently fails on pre-existing missing module type declarations for jsonrepair, openai, and @koa/cors)

Made with [Cursor](https://cursor.com)