### PR TITLE
[AGENT] Add gcal.updateEvent Google Calendar tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,4 @@ npm run ios
 | `gmail.forwardEmail` | Forward an email |
 | `gmail.resolveContact` | Look up a contact by name |
 | `gcal.createEvent` | Create a calendar event |
+| `gcal.updateEvent` | Update an existing calendar event |

--- a/app/src/api/gcalUpdateEvent.ts
+++ b/app/src/api/gcalUpdateEvent.ts
@@ -1,0 +1,96 @@
+import { GCAL_EVENTS_BASE } from './gcalGetEvents';
+
+export type GcalUpdateEventParams = {
+  accessToken: string;
+  eventId: string;
+  newSummary: string | null;
+  startIso: string | null;
+  endIso: string | null;
+  timeZone: string | null;
+  newLocation: string | null;
+  newDescription: string | null;
+  attendees: string[] | null;
+};
+
+export async function updateEvent({
+  accessToken,
+  eventId,
+  newSummary,
+  startIso,
+  endIso,
+  timeZone,
+  newLocation,
+  newDescription,
+  attendees,
+}: GcalUpdateEventParams) {
+  const patch: Record<string, unknown> = {};
+
+  if (newSummary != null) {
+    patch.summary = newSummary;
+  }
+  if (startIso != null && endIso != null && timeZone != null) {
+    patch.start = { dateTime: startIso, timeZone };
+    patch.end = { dateTime: endIso, timeZone };
+  }
+  if (newLocation != null) {
+    patch.location = newLocation;
+  }
+  if (newDescription != null) {
+    patch.description = newDescription;
+  }
+  if (attendees != null) {
+    patch.attendees = attendees.map((email) => ({ email }));
+  }
+
+  const notifyGuests =
+    patch.start != null ||
+    patch.end != null ||
+    patch.summary != null ||
+    patch.attendees != null;
+  const sendUpdates = notifyGuests ? 'all' : 'none';
+
+  const eventUrl = `${GCAL_EVENTS_BASE}/${encodeURIComponent(eventId)}`;
+  const url = `${eventUrl}?sendUpdates=${sendUpdates}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(patch),
+    });
+  } catch (error: any) {
+    console.error('[gcal.updateEvent] network error', {
+      message: error?.message,
+      eventId,
+      patch,
+    });
+    throw error;
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('[gcal.updateEvent] error response', {
+      status: res.status,
+      statusText: res.statusText,
+      body: text,
+      eventId,
+      patch,
+    });
+    throw new Error(`Failed to update event: ${res.status} ${text}`);
+  }
+
+  const data = await res.json();
+
+  return {
+    success: true,
+    eventId: data.id,
+    summary: data.summary ?? 'Untitled event',
+    start: data.start?.dateTime ?? data.start?.date ?? null,
+    end: data.end?.dateTime ?? data.end?.date ?? null,
+    htmlLink: data.htmlLink ?? null,
+  };
+}

--- a/app/src/api/toolExecutor.ts
+++ b/app/src/api/toolExecutor.ts
@@ -6,10 +6,11 @@ import { replyEmail } from "./replyEmail";
 import { forwardEmail } from "./forwardEmail";
 import { summarizeEmails } from "./summarizeEmails";
 import { emailCreateDraftSchema, resolveContactParametersSchema, emailSummarizeParametersSchema, readEmailParametersSchema, emailReplyParametersSchema, emailForwardParametersSchema } from "./toolSchemas/email";
-import { gcalCreateEventSchema, gcalGetEventsSchema, gcalRespondToEventSchema } from "./toolSchemas/gcal";
+import { gcalCreateEventSchema, gcalGetEventsSchema, gcalRespondToEventSchema, gcalUpdateEventSchema } from "./toolSchemas/gcal";
 import { createEvent } from "./gcalCreateEvent";
 import { getEvents } from "./gcalGetEvents";
 import { respondToEvent } from "./gcalRespondToEvent";
+import { updateEvent } from "./gcalUpdateEvent";
 
 export async function executeTool(tool: AgentTool, accessToken: string): Promise<ToolExecutionLog> {
   switch (tool.tool) {
@@ -105,6 +106,29 @@ export async function executeTool(tool: AgentTool, accessToken: string): Promise
         return { tool: tool.tool, status: 'success', result };
       } catch (e: any) {
         console.error('[executeTool] gcal.respondToEvent failed', {
+          toolParameters: tool.toolParameters,
+          message: e?.message,
+        });
+        return { tool: tool.tool, status: 'error', result: { message: e.message } };
+      }
+    }
+    case 'gcal.updateEvent': {
+      try {
+        const params = gcalUpdateEventSchema.parse(tool.toolParameters);
+        const result = await updateEvent({
+          accessToken,
+          eventId: params.eventId,
+          newSummary: params.newSummary,
+          startIso: params.startIso,
+          endIso: params.endIso,
+          timeZone: params.timeZone,
+          newLocation: params.newLocation,
+          newDescription: params.newDescription,
+          attendees: params.attendees,
+        });
+        return { tool: tool.tool, status: 'success', result };
+      } catch (e: any) {
+        console.error('[executeTool] gcal.updateEvent failed', {
           toolParameters: tool.toolParameters,
           message: e?.message,
         });

--- a/app/src/api/toolSchemas/gcal.ts
+++ b/app/src/api/toolSchemas/gcal.ts
@@ -22,3 +22,54 @@ export const gcalRespondToEventSchema = z.object({
   summary: z.string().nullable(),
   start: z.string().nullable(),
 });
+
+const gcalUpdateTimeRefine = (data: {
+  startIso: string | null;
+  endIso: string | null;
+  timeZone: string | null;
+}) => {
+  const anyTime = data.startIso != null || data.endIso != null || data.timeZone != null;
+  if (!anyTime) return true;
+  return data.startIso != null && data.endIso != null && data.timeZone != null;
+};
+
+const gcalUpdateHasPatchRefine = (data: {
+  newSummary: string | null;
+  startIso: string | null;
+  endIso: string | null;
+  timeZone: string | null;
+  newLocation: string | null;
+  newDescription: string | null;
+  attendees: string[] | null;
+}) => {
+  const timeOk =
+    data.startIso != null && data.endIso != null && data.timeZone != null;
+  return (
+    data.newSummary != null ||
+    timeOk ||
+    data.newLocation != null ||
+    data.newDescription != null ||
+    data.attendees != null
+  );
+};
+
+export const gcalUpdateEventSchema = z
+  .object({
+    eventId: z.string(),
+    summary: z.string().nullable(),
+    start: z.string().nullable(),
+    newSummary: z.string().nullable(),
+    startIso: z.string().nullable(),
+    endIso: z.string().nullable(),
+    timeZone: z.string().nullable(),
+    newLocation: z.string().nullable(),
+    newDescription: z.string().nullable(),
+    attendees: z.array(z.string()).nullable(),
+  })
+  .refine(gcalUpdateTimeRefine, {
+    message:
+      'When updating time, startIso, endIso, and timeZone must all be non-null.',
+  })
+  .refine(gcalUpdateHasPatchRefine, {
+    message: 'At least one field to update must be non-null.',
+  });

--- a/app/src/components/ToolIndicator.tsx
+++ b/app/src/components/ToolIndicator.tsx
@@ -19,6 +19,7 @@ const TOOL_ICONS: Record<string, React.ReactElement> = {
   'gcal.createEvent':      <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
   'gcal.getEvents':        <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
   'gcal.respondToEvent':   <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
+  'gcal.updateEvent':      <CalendarLogo size={ICON_SIZE} color={ICON_COLOR} />,
 };
 
 function ToolIcon({ toolName }: { toolName: string }) {
@@ -35,6 +36,7 @@ const TOOL_LABELS: Record<string, string> = {
   'gcal.createEvent': 'Calendar',
   'gcal.getEvents': 'Calendar',
   'gcal.respondToEvent': 'Calendar',
+  'gcal.updateEvent': 'Calendar',
 };
 
 interface Props {

--- a/app/src/utils/isToolReadyForExecution.ts
+++ b/app/src/utils/isToolReadyForExecution.ts
@@ -4,7 +4,7 @@ import {
   emailForwardParametersSchema,
   emailReplyParametersSchema,
 } from '../api/toolSchemas/email';
-import { gcalCreateEventSchema, gcalRespondToEventSchema } from '../api/toolSchemas/gcal';
+import { gcalCreateEventSchema, gcalRespondToEventSchema, gcalUpdateEventSchema } from '../api/toolSchemas/gcal';
 import * as z from 'zod';
 
 const EXECUTABLE_TOOL_SCHEMAS: Record<string, z.ZodTypeAny> = {
@@ -13,6 +13,7 @@ const EXECUTABLE_TOOL_SCHEMAS: Record<string, z.ZodTypeAny> = {
   'gmail.forwardEmail': emailForwardParametersSchema,
   'gcal.createEvent': gcalCreateEventSchema,
   'gcal.respondToEvent': gcalRespondToEventSchema,
+  'gcal.updateEvent': gcalUpdateEventSchema,
 };
 
 export function isToolReadyForExecution(tool: AgentTool | null | undefined): boolean {

--- a/server/src/api/Agent/actions/ExecutePermissionsActions.ts
+++ b/server/src/api/Agent/actions/ExecutePermissionsActions.ts
@@ -9,6 +9,7 @@ import { emailReplyParametersSchema } from "../tools/gmail/EmailReply";
 import { emailForwardParametersSchema } from "../tools/gmail/EmailForward";
 import { gcalCreateEventParametersSchema } from "../tools/gcal/GcalCreateEvent";
 import { gcalRespondToEventExecutableParametersSchema } from "../tools/gcal/GcalRespondToEvent";
+import { gcalUpdateEventExecutableParametersSchema } from "../tools/gcal/GcalUpdateEvent";
 
 export async function validateToolCall(tool: AgentTool): Promise<void>{
   switch (tool.tool) {
@@ -26,6 +27,9 @@ export async function validateToolCall(tool: AgentTool): Promise<void>{
       return;
     case 'gcal.respondToEvent':
       gcalRespondToEventExecutableParametersSchema.parse(tool.toolParameters);
+      return;
+    case 'gcal.updateEvent':
+      gcalUpdateEventExecutableParametersSchema.parse(tool.toolParameters);
       return;
     default:
       throw new Error(`Unsupported tool: ${tool.tool}`);

--- a/server/src/api/Agent/actions/PlanActions.ts
+++ b/server/src/api/Agent/actions/PlanActions.ts
@@ -13,6 +13,7 @@ import { emailForwardParametersSchema } from "../tools/gmail/EmailForward";
 import { gcalCreateEventParametersSchema } from "../tools/gcal/GcalCreateEvent";
 import { gcalGetEventsParametersSchema } from "../tools/gcal/GcalGetEvents";
 import { gcalRespondToEventParametersSchema } from "../tools/gcal/GcalRespondToEvent";
+import { gcalUpdateEventParametersSchema } from "../tools/gcal/GcalUpdateEvent";
 
 function formatZodError(err: any): string {
   if (err?.issues && Array.isArray(err.issues)) {
@@ -108,6 +109,9 @@ export const verifyLLMToolCall = (plan: LLMPlanResponse) => {
       return;
     case "gcal.respondToEvent":
       plan.toolParameters = gcalRespondToEventParametersSchema.parse(plan.toolParameters);
+      return;
+    case "gcal.updateEvent":
+      plan.toolParameters = gcalUpdateEventParametersSchema.parse(plan.toolParameters);
       return;
   }
 };

--- a/server/src/api/Agent/tools/gcal/GcalGetEvents.ts
+++ b/server/src/api/Agent/tools/gcal/GcalGetEvents.ts
@@ -14,7 +14,7 @@ export const gcalGetEventsParametersSchema = z.object({
 
 export const GCAL_GET_EVENTS_INSTRUCTIONS = `
   1. "gcal.getEvents"
-  Use this tool when the user asks about their agenda, schedule, upcoming events, what is on their calendar, or when you need to identify an existing calendar event before using gcal.respondToEvent.
+  Use this tool when the user asks about their agenda, schedule, upcoming events, what is on their calendar, or when you need to identify an existing calendar event before using gcal.respondToEvent or gcal.updateEvent.
   This is a SILENT tool. Do not ask for confirmation before using it. Call it immediately when the user is asking to check their calendar.
   When calling this tool, set the "assistant" message to a brief status like "Let me check your calendar." or "Looking up your schedule for [time range]."
   When you decide to use this tool, output JSON with:
@@ -37,6 +37,7 @@ export const GCAL_GET_EVENTS_INSTRUCTIONS = `
   - Summarize the events in chronological order.
   - Mention the title, time, and location when useful.
   - When the user is trying to RSVP to an event, use the returned event id, title, and start time to continue with gcal.respondToEvent.
+  - When the user wants to edit or reschedule an event, use the returned event id, title, and start time to continue with gcal.updateEvent.
   - If more than one returned event could match the user's request, ask a clarifying question instead of guessing.
   - If no events are returned, tell the user their calendar is clear for that time range.
 `;

--- a/server/src/api/Agent/tools/gcal/GcalUpdateEvent.ts
+++ b/server/src/api/Agent/tools/gcal/GcalUpdateEvent.ts
@@ -1,0 +1,93 @@
+import * as z from "zod";
+
+export type gcalUpdateEventParameters = {
+  eventId: string | null;
+  summary: string | null;
+  start: string | null;
+  newSummary: string | null;
+  startIso: string | null;
+  endIso: string | null;
+  timeZone: string | null;
+  newLocation: string | null;
+  newDescription: string | null;
+  attendees: string[] | null;
+};
+
+export const gcalUpdateEventParametersSchema = z.object({
+  eventId: z.string().nullable(),
+  summary: z.string().nullable(),
+  start: z.string().nullable(),
+  newSummary: z.string().nullable(),
+  startIso: z.string().nullable(),
+  endIso: z.string().nullable(),
+  timeZone: z.string().nullable(),
+  newLocation: z.string().nullable(),
+  newDescription: z.string().nullable(),
+  attendees: z.array(z.string()).nullable(),
+}) satisfies z.ZodType<gcalUpdateEventParameters>;
+
+const timeUpdateRefine = (data: gcalUpdateEventParameters) => {
+  const anyTime = data.startIso != null || data.endIso != null || data.timeZone != null;
+  if (!anyTime) return true;
+  return data.startIso != null && data.endIso != null && data.timeZone != null;
+};
+
+const hasPatchRefine = (data: gcalUpdateEventParameters) => {
+  const timeOk =
+    data.startIso != null && data.endIso != null && data.timeZone != null;
+  return (
+    data.newSummary != null ||
+    timeOk ||
+    data.newLocation != null ||
+    data.newDescription != null ||
+    data.attendees != null
+  );
+};
+
+export const gcalUpdateEventExecutableParametersSchema = z
+  .object({
+    eventId: z.string(),
+    summary: z.string().nullable(),
+    start: z.string().nullable(),
+    newSummary: z.string().nullable(),
+    startIso: z.string().nullable(),
+    endIso: z.string().nullable(),
+    timeZone: z.string().nullable(),
+    newLocation: z.string().nullable(),
+    newDescription: z.string().nullable(),
+    attendees: z.array(z.string()).nullable(),
+  })
+  .refine(timeUpdateRefine, {
+    message:
+      "When updating time, startIso, endIso, and timeZone must all be non-null.",
+  })
+  .refine(hasPatchRefine, {
+    message: "At least one field to update must be non-null.",
+  });
+
+export const GCAL_UPDATE_EVENT_INSTRUCTIONS = `
+  1. "gcal.updateEvent"
+  Use this tool when the user wants to change an existing Google Calendar event: reschedule, rename, change location or description, or change who is invited.
+  If the event is not already clearly identified, use gcal.getEvents first and use the returned event id. NEVER invent or guess eventId.
+  When you decide to use this tool, output JSON with:
+  - assistantMessage (string) — a brief spoken confirmation of the event and the changes you are about to make
+  - tool: "gcal.updateEvent"
+  - toolParameters:
+    - eventId: string | null — the Google Calendar event id from a prior gcal.getEvents result.
+    - summary: string | null — the current event title from gcal.getEvents when available, for confirmation to the user.
+    - start: string | null — the current event start from gcal.getEvents when available, for confirmation to the user.
+    - newSummary: string | null — new title if the user is renaming the event; otherwise null.
+    - startIso: string | null — new start datetime in ISO 8601 with UTC offset when changing time; otherwise null. If you set this, you MUST also set endIso and timeZone.
+    - endIso: string | null — new end datetime in ISO 8601 with UTC offset when changing time; otherwise null.
+    - timeZone: string | null — IANA timezone when changing time (e.g. "America/New_York"); otherwise null.
+    - newLocation: string | null — new location or meeting link if the user is changing it; otherwise null.
+    - newDescription: string | null — new description or notes if the user is changing them; otherwise null.
+    - attendees: string[] | null — full replacement attendee email list if the user is changing guests; otherwise null. Do NOT guess emails; use gmail.resolveContact for unresolved names, same as gcal.createEvent.
+
+  If any of startIso, endIso, or timeZone is non-null, all three MUST be non-null. At least one of newSummary, time fields (all three), newLocation, newDescription, or attendees must be non-null when executing.
+  If there are multiple plausible events, ask the user to clarify before calling this tool.
+  This tool is NOT silent. Confirm the event and the changes in natural language. Only call the tool once the user has confirmed.
+  When you see the gcal.updateEvent result in the conversation:
+  - Confirm the calendar was updated successfully.
+  - Mention the event title and what changed in natural language.
+`;

--- a/server/src/api/Agent/tools/gmail/ResolveContact.ts
+++ b/server/src/api/Agent/tools/gmail/ResolveContact.ts
@@ -23,7 +23,7 @@ export const RESOLVE_CONTACT_INSTRUCTIONS = `
   After receiving the result:
   - If status is "resolved": use resolvedEmail in the downstream tool you are building.
   - If status is "resolved" for gmail.createDraft, gmail.replyToEmail, or gmail.forwardEmail: use resolvedEmail as the "to" parameter.
-  - If status is "resolved" for gcal.createEvent: add resolvedEmail to the "attendees" array and preserve any attendees you already resolved earlier in the conversation.
+  - If status is "resolved" for gcal.createEvent or gcal.updateEvent: add resolvedEmail to the "attendees" array and preserve any attendees you already resolved earlier in the conversation.
   - If status is "resolved" and other recipients or attendees from the user's request are still unresolved, immediately call gmail.resolveContact again for the next unresolved person instead of asking for confirmation yet.
   - If status is "no_match": ask the user to spell out that person's email address.
 `;

--- a/server/src/api/Agent/utils/AgentToolSpec.ts
+++ b/server/src/api/Agent/utils/AgentToolSpec.ts
@@ -7,6 +7,7 @@ import { EMAIL_FORWARD_INSTRUCTIONS } from "../tools/gmail/EmailForward";
 import { GCAL_CREATE_EVENT_INSTRUCTIONS } from "../tools/gcal/GcalCreateEvent";
 import { GCAL_GET_EVENTS_INSTRUCTIONS } from "../tools/gcal/GcalGetEvents";
 import { GCAL_RESPOND_TO_EVENT_INSTRUCTIONS } from "../tools/gcal/GcalRespondToEvent";
+import { GCAL_UPDATE_EVENT_INSTRUCTIONS } from "../tools/gcal/GcalUpdateEvent";
 
 export const ALL_TOOLS_DESCRIPTION = `
   ${EMAIL_CREATE_DRAFT_INSTRUCTIONS}\n
@@ -18,4 +19,5 @@ export const ALL_TOOLS_DESCRIPTION = `
   ${GCAL_CREATE_EVENT_INSTRUCTIONS}\n
   ${GCAL_GET_EVENTS_INSTRUCTIONS}\n
   ${GCAL_RESPOND_TO_EVENT_INSTRUCTIONS}
+  ${GCAL_UPDATE_EVENT_INSTRUCTIONS}
   `;

--- a/server/src/api/Agent/utils/PlanInstructions.ts
+++ b/server/src/api/Agent/utils/PlanInstructions.ts
@@ -40,7 +40,7 @@ Rules:
 - If any required parameter is missing, ask the user for it (ask for one missing parameter at a time), then set it.
 - Never invent recipients, subjects, or email body content. If not provided, leave null until the user supplies it.
 - Once you have all required parameters, in the assistant message, you must ask them for confirmation to execute the tool.
-- After receiving a silent tool result (e.g. gmail.resolveContact), you must return the main non-silent tool you are building (e.g. gmail.createDraft, gcal.createEvent) with its current parameters. Fill in any parameters that were resolved; leave unresolved ones as null. Never return tool as null or empty while a non-silent tool is still in progress.
+- After receiving a silent tool result (e.g. gmail.resolveContact), you must return the main non-silent tool you are building (e.g. gmail.createDraft, gcal.createEvent, gcal.updateEvent) with its current parameters. Fill in any parameters that were resolved; leave unresolved ones as null. Never return tool as null or empty while a non-silent tool is still in progress.
 - When asking the user a clarifying question (e.g. which email to use), still return the main tool with its current parameters. The tool should remain visible while you gather information.
 - When calling a silent tool, the "assistant" message will be spoken aloud to the user via text-to-speech. Write a brief, natural status update that tells the user what you're about to do (e.g."Finding John's email" or "Checking your calendar for tomorrow"). Keep it to one very short sentence.
 `;

--- a/server/src/api/Agent/utils/isSilent.test.ts
+++ b/server/src/api/Agent/utils/isSilent.test.ts
@@ -21,6 +21,10 @@ describe('isSilent()', () => {
     expect(isSilent({ tool: "gcal.respondToEvent", toolParameters: null })).toBe(false);
   });
 
+  it("returns false for gcal.updateEvent", () => {
+    expect(isSilent({ tool: "gcal.updateEvent", toolParameters: null })).toBe(false);
+  });
+
   it("returns false for an unknown tool", () => {
     expect(isSilent({ tool: "unknown.tool", toolParameters: null })).toBe(false);
   });


### PR DESCRIPTION
## What
Adds a new agent tool `gcal.updateEvent` that PATCHes an existing primary-calendar event via the Calendar API. The server registers LLM instructions and Zod validation; the app implements execution (partial fields, `sendUpdates` when guests or time/title change), permission validation, and UI tool labels.

## Why
Users can reschedule, rename, or otherwise edit events they already have; previously only create, list, and RSVP were supported.

## Verification
- `cd server && npm install && npx tsc --noEmit`
- `cd server && npm test` (includes `isSilent` coverage for the new tool)

Made with [Cursor](https://cursor.com)