### PR TITLE
[AGENT] Early-morning disambiguation for calendar "tomorrow"

### DIFF
--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -28,18 +28,64 @@ const KOKORO_MODEL_DIR = `${RNFS.MainBundlePath}/sherpa-onnx-kokoro-en-v0_19`;
 const DEV_TEXT_MODE = true;
 const DATE_CONTEXT_PREFIX = 'Current local time:';
 
+function localHourInTimeZone(d: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour: 'numeric',
+    hour12: false,
+  }).formatToParts(d);
+  const hourStr = parts.find((p) => p.type === 'hour')?.value;
+  return hourStr != null ? parseInt(hourStr, 10) : d.getHours();
+}
+
+function formatLocalDate(
+  d: Date,
+  timeZone: string,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  return d.toLocaleDateString('en-US', { timeZone, ...options });
+}
+
 function buildDateContextMessage(): Message {
   const now = new Date();
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const localHour = localHourInTimeZone(now, timeZone);
+
+  const dateLine = {
+    weekday: 'long' as const,
+    year: 'numeric' as const,
+    month: 'long' as const,
+    day: 'numeric' as const,
+  };
+
+  const todayLong = formatLocalDate(now, timeZone, dateLine);
+  const tomorrowDate = new Date(now);
+  tomorrowDate.setDate(tomorrowDate.getDate() + 1);
+  const tomorrowLong = formatLocalDate(tomorrowDate, timeZone, dateLine);
+
+  const localTimeVerbose = now.toLocaleString('en-US', {
+    timeZone,
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+  });
+
+  let content = `${DATE_CONTEXT_PREFIX} ${now.toISOString()} (${timeZone}). Local time: ${localTimeVerbose}. Calendar today: ${todayLong}. Calendar tomorrow: ${tomorrowLong}.`;
+
+  const isEarlyMorning = localHour >= 0 && localHour < 4;
+  if (isEarlyMorning) {
+    content +=
+      ` Early-morning disambiguation: In the first hours after local midnight, when the user says "tomorrow" without a specific date, they often mean today's calendar day (still thinking in terms of the evening before), not the next calendar day. For gcal.getEvents, still call the tool immediately: use today's full-day range as the primary interpretation. In your final spoken reply after summarizing results, briefly acknowledge the ambiguity and offer the other reading (for example ask if they meant ${tomorrowLong} instead, and offer to check that day if they say yes).`;
+  }
 
   return {
     role: 'system',
-    content: `${DATE_CONTEXT_PREFIX} ${now.toISOString()} (${timeZone}). Today is ${now.toLocaleDateString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    })}.`,
+    content,
   };
 }
 

--- a/server/src/api/Agent/tools/gcal/GcalGetEvents.ts
+++ b/server/src/api/Agent/tools/gcal/GcalGetEvents.ts
@@ -26,7 +26,7 @@ export const GCAL_GET_EVENTS_INSTRUCTIONS = `
 
   Derive timeMin and timeMax from natural language relative to today's date:
   - "today": start of today through end of today
-  - "tomorrow": start of tomorrow through end of tomorrow
+  - "tomorrow": normally start of tomorrow through end of tomorrow. Exception: if the conversation's date context includes an early-morning note (local time roughly midnight through 3:59 AM) and the user says "tomorrow" without naming a calendar date, treat that as ambiguous — use today's full-day range for this tool call first (same as "today"). After you summarize the results, briefly offer the strict reading (the next calendar day) in case they meant that instead.
   - "this week": start of the current week through end of the current week
   - "next week": start of next week through end of next week
   - "this afternoon" or "this evening": use the corresponding time window today


### PR DESCRIPTION
## What
- Expand the system date context in `VoiceDashboard2` with explicit local calendar **today** and **tomorrow** labels and a readable local timestamp.
- Between local midnight and 3:59 AM, append guidance: bare "tomorrow" is ambiguous — still call `gcal.getEvents` immediately using **today's** full-day range first, then briefly offer the strict next-calendar-day reading in the final spoken reply.
- Update `GcalGetEvents` tool instructions so the server-side planner matches that behavior when the date context includes the early-morning note.

## Why
Right after midnight, people often say "tomorrow" meaning the calendar day they still think of as "after tonight" (i.e. today), not the next calendar day. The previous instructions always mapped "tomorrow" to the next day, so a 12:12 AM Friday request could query Saturday and miss Friday events. This change biases the first lookup toward today in that window and surfaces the alternative in speech.

## Verify
- `server`: `npx tsc --noEmit` passes.
- `app`: `npx tsc --noEmit` reports existing project issues unrelated to this change.

Made with [Cursor](https://cursor.com)