### PR TITLE
[AGENT] Hide tool panel when plan has no tool name

### DIFF
--- a/app/src/components/ToolIndicator.tsx
+++ b/app/src/components/ToolIndicator.tsx
@@ -121,7 +121,6 @@ const vizStyles = StyleSheet.create({
 
 export default function ToolIndicator({ tool: toolProp }: Props) {
   const tool = toolProp;
-  const displayName = tool ? (TOOL_LABELS[tool.tool] ?? tool.tool) : null;
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const contentFade = useRef(new Animated.Value(0)).current;
   const prevToolKey = useRef<string | null>(null);
@@ -135,7 +134,7 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
   }, [fadeAnim]);
 
   useEffect(() => {
-    const toolKey = tool
+    const toolKey = tool?.tool
       ? `${tool.tool}:${JSON.stringify(tool.toolParameters)}`
       : null;
     if (toolKey !== prevToolKey.current) {
@@ -148,6 +147,12 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
       prevToolKey.current = toolKey;
     }
   }, [tool, contentFade]);
+
+  if (!tool?.tool) {
+    return null;
+  }
+
+  const displayName = TOOL_LABELS[tool.tool] ?? tool.tool;
 
   return (
     <Animated.View style={[styles.wrapper, { opacity: fadeAnim }]}>
@@ -168,20 +173,16 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
           showsVerticalScrollIndicator={false}
           showsHorizontalScrollIndicator={false}
         >
-          {tool ? (
-            <Animated.View style={{ opacity: contentFade }}>
-              <View style={styles.header}>
-                <ToolIcon toolName={tool.tool} />
-                <Text style={styles.headerLabel}>{displayName}</Text>
-                {tool.tool ? (
-                  <View style={styles.toolBadge}>
-                    <Text style={styles.toolBadgeText}>{tool.tool}</Text>
-                  </View>
-                ) : null}
+          <Animated.View style={{ opacity: contentFade }}>
+            <View style={styles.header}>
+              <ToolIcon toolName={tool.tool} />
+              <Text style={styles.headerLabel}>{displayName}</Text>
+              <View style={styles.toolBadge}>
+                <Text style={styles.toolBadgeText}>{tool.tool}</Text>
               </View>
-              <GenericToolViz tool={tool} />
-            </Animated.View>
-          ) : null}
+            </View>
+            <GenericToolViz tool={tool} />
+          </Animated.View>
         </ScrollView>
       </LinearGradient>
     </Animated.View>

--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -183,9 +183,7 @@ export default function VoiceDashboard2() {
 
     setMessages([...currentMessages]);
 
-    if (currentResult.tool?.tool) {
-      setTool(currentResult.tool);
-    }
+    setTool(currentResult.tool?.tool ? currentResult.tool : null);
 
     while (currentResult.tool?.silent && iterations < MAX_SILENT_ITERATIONS) {
       iterations++;
@@ -214,9 +212,7 @@ export default function VoiceDashboard2() {
       setMessages([...currentMessages]);
 
       if (speakPromise) await speakPromise;
-      if (currentResult.tool?.tool) {
-        setTool(currentResult.tool);
-      }
+      setTool(currentResult.tool?.tool ? currentResult.tool : null);
     }
 
     const hitLoopLimit = iterations >= MAX_SILENT_ITERATIONS && currentResult.tool?.silent;
@@ -265,9 +261,7 @@ export default function VoiceDashboard2() {
           currentMessages = [...currentMessages, result.message];
           setMessages([...currentMessages]);
 
-          if (result.tool?.tool) {
-            setTool(result.tool);
-          }
+          setTool(result.tool?.tool ? result.tool : null);
 
           if (!authToken) {
             throw new Error('No auth gmail accesstoken');
@@ -287,9 +281,7 @@ export default function VoiceDashboard2() {
           currentMessages = [...currentMessages, result.message];
           setMessages([...currentMessages]);
 
-          if (result.tool?.tool) {
-            setTool(result.tool);
-          }
+          setTool(result.tool?.tool ? result.tool : null);
 
           await speak({
             text: result.message.content,

--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -183,7 +183,7 @@ export default function VoiceDashboard2() {
 
     setMessages([...currentMessages]);
 
-    if (currentResult.tool) {
+    if (currentResult.tool?.tool) {
       setTool(currentResult.tool);
     }
 
@@ -214,7 +214,7 @@ export default function VoiceDashboard2() {
       setMessages([...currentMessages]);
 
       if (speakPromise) await speakPromise;
-      if (currentResult.tool) {
+      if (currentResult.tool?.tool) {
         setTool(currentResult.tool);
       }
     }
@@ -249,6 +249,9 @@ export default function VoiceDashboard2() {
       ));
       let currentMessages = [dateContext, ...priorMessages, userMessage];
       setMessages([...currentMessages]);
+      if (!pendingTool) {
+        setTool(null);
+      }
 
       const result = await sendAgentMessage(currentMessages, pendingTool);
 
@@ -262,7 +265,7 @@ export default function VoiceDashboard2() {
           currentMessages = [...currentMessages, result.message];
           setMessages([...currentMessages]);
 
-          if (result.tool) {
+          if (result.tool?.tool) {
             setTool(result.tool);
           }
 
@@ -284,7 +287,7 @@ export default function VoiceDashboard2() {
           currentMessages = [...currentMessages, result.message];
           setMessages([...currentMessages]);
 
-          if (result.tool) {
+          if (result.tool?.tool) {
             setTool(result.tool);
           }
 


### PR DESCRIPTION
## What
- Set `tool` state to `null` whenever the plan response has no non-empty `tool.tool` (including the API’s empty-string stand-in for `tool: null`).
- `ToolIndicator` returns `null` when there is no named tool, so no glass panel or default email icon is shown.
- On a new user message, still clear `tool` when there is no pending confirmation flow so the UI does not show a stale tool while waiting.

## Why
Plans that only speak a final answer after a silent step (e.g. `gcal.getEvents`) used to leave misleading UI (empty tool object or wrong fallback icon). Hiding the panel when there is nothing to display matches user expectations and keeps the implementation straightforward.