### PR TITLE
[AGENT] Tool panel: hide without tool and skip unknown-tool icons

### DIFF
--- a/app/src/components/ToolIndicator.tsx
+++ b/app/src/components/ToolIndicator.tsx
@@ -24,7 +24,7 @@ const TOOL_ICONS: Record<string, React.ReactElement> = {
 };
 
 function ToolIcon({ toolName }: { toolName: string }) {
-  return TOOL_ICONS[toolName] ?? <EmailLogo size={ICON_SIZE} color={ICON_COLOR} />;
+  return TOOL_ICONS[toolName] ?? null;
 }
 
 const TOOL_LABELS: Record<string, string> = {
@@ -134,8 +134,9 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
   }, [fadeAnim]);
 
   useEffect(() => {
-    const toolKey = tool?.tool
-      ? `${tool.tool}:${JSON.stringify(tool.toolParameters)}`
+    const trimmed = (tool?.tool ?? '').trim();
+    const toolKey = trimmed
+      ? `${trimmed}:${JSON.stringify(tool?.toolParameters)}`
       : null;
     if (toolKey !== prevToolKey.current) {
       contentFade.setValue(0);
@@ -148,11 +149,15 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
     }
   }, [tool, contentFade]);
 
-  if (!tool?.tool) {
+  if (!tool) {
+    return null;
+  }
+  const toolName = (tool.tool ?? '').trim();
+  if (!toolName) {
     return null;
   }
 
-  const displayName = TOOL_LABELS[tool.tool] ?? tool.tool;
+  const displayName = TOOL_LABELS[toolName] ?? toolName;
 
   return (
     <Animated.View style={[styles.wrapper, { opacity: fadeAnim }]}>
@@ -175,10 +180,10 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
         >
           <Animated.View style={{ opacity: contentFade }}>
             <View style={styles.header}>
-              <ToolIcon toolName={tool.tool} />
+              <ToolIcon toolName={toolName} />
               <Text style={styles.headerLabel}>{displayName}</Text>
               <View style={styles.toolBadge}>
-                <Text style={styles.toolBadgeText}>{tool.tool}</Text>
+                <Text style={styles.toolBadgeText}>{toolName}</Text>
               </View>
             </View>
             <GenericToolViz tool={tool} />

--- a/app/src/components/ToolIndicator.tsx
+++ b/app/src/components/ToolIndicator.tsx
@@ -121,7 +121,6 @@ const vizStyles = StyleSheet.create({
 
 export default function ToolIndicator({ tool: toolProp }: Props) {
   const tool = toolProp;
-  const displayName = tool ? (TOOL_LABELS[tool.tool] ?? tool.tool) : null;
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const contentFade = useRef(new Animated.Value(0)).current;
   const prevToolKey = useRef<string | null>(null);
@@ -135,7 +134,7 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
   }, [fadeAnim]);
 
   useEffect(() => {
-    const toolKey = tool
+    const toolKey = tool?.tool
       ? `${tool.tool}:${JSON.stringify(tool.toolParameters)}`
       : null;
     if (toolKey !== prevToolKey.current) {
@@ -148,6 +147,12 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
       prevToolKey.current = toolKey;
     }
   }, [tool, contentFade]);
+
+  if (!tool?.tool) {
+    return null;
+  }
+
+  const displayName = TOOL_LABELS[tool.tool] ?? tool.tool;
 
   return (
     <Animated.View style={[styles.wrapper, { opacity: fadeAnim }]}>
@@ -168,20 +173,16 @@ export default function ToolIndicator({ tool: toolProp }: Props) {
           showsVerticalScrollIndicator={false}
           showsHorizontalScrollIndicator={false}
         >
-          {tool ? (
-            <Animated.View style={{ opacity: contentFade }}>
-              <View style={styles.header}>
-                <ToolIcon toolName={tool.tool} />
-                <Text style={styles.headerLabel}>{displayName}</Text>
-                {tool.tool ? (
-                  <View style={styles.toolBadge}>
-                    <Text style={styles.toolBadgeText}>{tool.tool}</Text>
-                  </View>
-                ) : null}
+          <Animated.View style={{ opacity: contentFade }}>
+            <View style={styles.header}>
+              <ToolIcon toolName={tool.tool} />
+              <Text style={styles.headerLabel}>{displayName}</Text>
+              <View style={styles.toolBadge}>
+                <Text style={styles.toolBadgeText}>{tool.tool}</Text>
               </View>
-              <GenericToolViz tool={tool} />
-            </Animated.View>
-          ) : null}
+            </View>
+            <GenericToolViz tool={tool} />
+          </Animated.View>
         </ScrollView>
       </LinearGradient>
     </Animated.View>

--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -183,9 +183,7 @@ export default function VoiceDashboard2() {
 
     setMessages([...currentMessages]);
 
-    if (currentResult.tool?.tool) {
-      setTool(currentResult.tool);
-    }
+    setTool(currentResult.tool?.tool ? currentResult.tool : null);
 
     while (currentResult.tool?.silent && iterations < MAX_SILENT_ITERATIONS) {
       iterations++;
@@ -214,9 +212,7 @@ export default function VoiceDashboard2() {
       setMessages([...currentMessages]);
 
       if (speakPromise) await speakPromise;
-      if (currentResult.tool?.tool) {
-        setTool(currentResult.tool);
-      }
+      setTool(currentResult.tool?.tool ? currentResult.tool : null);
     }
 
     const hitLoopLimit = iterations >= MAX_SILENT_ITERATIONS && currentResult.tool?.silent;
@@ -265,9 +261,7 @@ export default function VoiceDashboard2() {
           currentMessages = [...currentMessages, result.message];
           setMessages([...currentMessages]);
 
-          if (result.tool?.tool) {
-            setTool(result.tool);
-          }
+          setTool(result.tool?.tool ? result.tool : null);
 
           if (!authToken) {
             throw new Error('No auth gmail accesstoken');
@@ -287,9 +281,7 @@ export default function VoiceDashboard2() {
           currentMessages = [...currentMessages, result.message];
           setMessages([...currentMessages]);
 
-          if (result.tool?.tool) {
-            setTool(result.tool);
-          }
+          setTool(result.tool?.tool ? result.tool : null);
 
           await speak({
             text: result.message.content,

--- a/app/src/screens/VoiceDashboard2.tsx
+++ b/app/src/screens/VoiceDashboard2.tsx
@@ -183,7 +183,7 @@ export default function VoiceDashboard2() {
 
     setMessages([...currentMessages]);
 
-    if (currentResult.tool) {
+    if (currentResult.tool?.tool) {
       setTool(currentResult.tool);
     }
 
@@ -214,7 +214,7 @@ export default function VoiceDashboard2() {
       setMessages([...currentMessages]);
 
       if (speakPromise) await speakPromise;
-      if (currentResult.tool) {
+      if (currentResult.tool?.tool) {
         setTool(currentResult.tool);
       }
     }
@@ -249,6 +249,9 @@ export default function VoiceDashboard2() {
       ));
       let currentMessages = [dateContext, ...priorMessages, userMessage];
       setMessages([...currentMessages]);
+      if (!pendingTool) {
+        setTool(null);
+      }
 
       const result = await sendAgentMessage(currentMessages, pendingTool);
 
@@ -262,7 +265,7 @@ export default function VoiceDashboard2() {
           currentMessages = [...currentMessages, result.message];
           setMessages([...currentMessages]);
 
-          if (result.tool) {
+          if (result.tool?.tool) {
             setTool(result.tool);
           }
 
@@ -284,7 +287,7 @@ export default function VoiceDashboard2() {
           currentMessages = [...currentMessages, result.message];
           setMessages([...currentMessages]);
 
-          if (result.tool) {
+          if (result.tool?.tool) {
             setTool(result.tool);
           }
 


### PR DESCRIPTION
## What
- `ToolIndicator` returns nothing when `tool` is missing or the tool name is empty after trimming (including whitespace-only names).
- The header icon is shown only for tools listed in `TOOL_ICONS`; there is no default email icon for unknown tool names.
- The fade animation key uses the trimmed name so it stays consistent with what we render.

## Why
Users should not see a tool affordance (panel or generic icon) when the agent is not calling a concrete tool, or when the tool name is not one we visualize. That avoids misleading UI and matches the voice dashboard’s `setTool` behavior for empty names.

Made with [Cursor](https://cursor.com)